### PR TITLE
Update design and layout

### DIFF
--- a/app/assets/sass/_header.scss
+++ b/app/assets/sass/_header.scss
@@ -1,3 +1,8 @@
-.app-header__container--pink {
+.app-header {
   border-bottom-color: govuk-colour("pink");
+}
+
+.app-header__container--pink {
+  border-bottom-width: 0;
+  margin-bottom: 0;
 }

--- a/app/assets/sass/_navigation.scss
+++ b/app/assets/sass/_navigation.scss
@@ -1,0 +1,56 @@
+$navigation-height: 50px;
+
+.app-navigation {
+  @include govuk-font(19, $weight: bold);
+  box-sizing: border-box;
+  width: 100%;
+  background-color: $app-light-grey;
+
+  @include govuk-media-query($until: tablet) {
+    display: none;
+  }
+}
+
+.app-navigation__list {
+  position: relative;
+  left: -(govuk-spacing(3));
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.app-navigation__list-item {
+  box-sizing: border-box;
+  display: block;
+  position: relative;
+  height: $navigation-height;
+  padding: 0 govuk-spacing(3);
+  float: left;
+  line-height: $navigation-height;
+}
+
+.app-navigation__list-item--current {
+  border-bottom: 4px solid govuk-colour("blue");
+}
+
+.app-navigation__link {
+  @include govuk-typography-weight-bold;
+
+  &:not(:focus):hover {
+    color: $govuk-link-colour;
+  }
+
+  // Extend the touch area of the link to the list
+  &:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+}
+
+.app-navigation__list-item--current .app-navigation__link:hover {
+  text-decoration: none;
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,8 +1,21 @@
 $govuk-new-link-styles: true;
+
+// Override the default GOV.UK Frontend font stack
+$govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+
 @import "node_modules/govuk-frontend/govuk/all";
+
+// App-specific variables
+$app-light-grey: #f8f8f8;
 
 @import "count";
 @import "header";
 @import "list";
 @import "logo";
+@import "navigation";
 @import "tag";
+
+// We don't change the global width container width so that examples are the current width.
+.app-width-container {
+  @include govuk-width-container(1100px);
+}

--- a/app/views/includes/_header.html
+++ b/app/views/includes/_header.html
@@ -1,32 +1,34 @@
-<header class="govuk-header " role="banner" data-module="govuk-header">
+<header class="govuk-header app-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container app-header__container--pink">
     <div class="govuk-header__logo app-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
-        Government digital services
+        UK Government digital services
       </a>
-
-    <nav>
-      <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-        <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="/">
-            By theme
-          </a>
-        </li>
-        <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="/organisation">
-            By organisation
-          </a>
-        </li>
-        <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="/contribute">
-            Contribute
-          </a>
-        </li>
-      </ul>
-    </nav>
-
     </div>
-
-
   </div>
 </header>
+
+
+<nav class="app-navigation govuk-clearfix">
+  <div class="govuk-width-container">
+    <ul class="app-navigation__list">
+
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link" href="/">
+          By theme
+        </a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link" href="/organisation">
+          By organisation
+        </a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link" href="/contribute">
+          Contribute
+        </a>
+      </li>
+
+    </ul>
+  </div>
+</nav>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -6,7 +6,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <p class="govuk-body">These are some of the things government is doing.</p>
+      <p class="govuk-body">A catalogue of government services that are fully digital as part of GOV.UK</p>
     </div>
   </div>
 
@@ -27,28 +27,21 @@
 
   {% for theme in themes %}
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
+      <div class="govuk-grid-column-two-thirds">
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
         <h2 class="govuk-heading-l">{{ theme }}</h2>
+
+        <ul class="govuk-list">
+          {%- for project in projects -%}
+            {% if project.theme == theme %}
+              <li>
+                <a class="govuk-link" href="/projects/{{project.slug }}">{{ project.name }}</a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
       </div>
     </div>
-
-    <div class="govuk-grid-row">
-
-      {%- for phase in phases -%}
-        <div class="govuk-grid-column-one-quarter">
-          <div class="govuk-body"></div>
-          <ul class="govuk-list app-list--projects app-list--{{ phase.name }}">
-            {%- for project in projects -%}
-              {% if project.phase == phase.name and project.theme == theme %}
-                <li><a class="govuk-link" href="/projects/{{project.slug }}">{{ project.name }}</a></li>
-
-              {% endif %}
-            {% endfor %}
-          </ul>
-        </div>
-      {%- endfor -%}
-    </div>
-  {%- endfor -%}
+  {% endfor %}
 
 {% endblock %}

--- a/app/views/organisations.html
+++ b/app/views/organisations.html
@@ -4,40 +4,27 @@
 {% block pageTitle %}By organisation: Government digital services{% endblock %}
 {% block content %}
 
-  <div class="govuk-grid-row">
-    {% for phase in phases %}
-      <div class="govuk-grid-column-one-quarter">
-        {{ govukTag({
-          text: phase.name,
-          classes: "app-tag--large govuk-tag--" + phase.class
-        }) }}
-      </div>
-    {% endfor %}
-  </div>
+  <h1 class="govuk-heading-xl">By organisation</h1>
 
   {% for organisation in organisations %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
         <h2 class="govuk-heading-l" id="{{ organisation | slugify }}">{{ organisation }}</h2>
+
+        <ul class="govuk-list">
+          {%- for project in projects -%}
+            {% if project.organisation == organisation %}
+              <li>
+                <a class="govuk-link" href="/projects/{{project.slug }}">{{ project.name }}</a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
       </div>
     </div>
 
-    <div class="govuk-grid-row">
-      {%- for phase in phases -%}
-        <div class="govuk-grid-column-one-quarter">
-          <div class="govuk-body"></div>
-          <ul class="govuk-list app-list--projects app-list--{{ phase.name }}">
-            {%- for project in projects -%}
-              {% if project.phase == phase.name and project.organisation == organisation %}
-                <li><a class="govuk-link" href="/projects/{{project.slug }}">{{ project.name }}</a></li>
-
-              {% endif %}
-            {% endfor %}
-          </ul>
-        </div>
-      {%- endfor -%}
-    </div>
   {%- endfor -%}
 
 {% endblock %}

--- a/app/views/project.html
+++ b/app/views/project.html
@@ -32,22 +32,72 @@
         </div>
       {% endif %}
 
-    </div>
-    <div class="govuk-grid-column-one-third">
 
-      {% if project.phase %}
+      {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+      {% set organisationHtml %}
+        <a class="govuk-link" href="/organisation/#{{ project.organisation | slugify }}">{{ project.organisation }}</a>
+      {% endset %}
+
+      {% set themeHtml %}
+        <a class="govuk-link" href="/#{{ project.theme | slugify }}">{{ project.theme }}</a>
+      {% endset %}
+
+      {% set statusHtml %}
         {{ govukTag({
             text: project.phase
         }) }}
-      {% endif %}
+      {% endset %}
 
-      <p class="govuk-body">Built by: <a class="govuk-link" href="/organisation/#{{ project.organisation | slugify }}">{{ project.organisation }}</a></p>
+      {% set sourceCodeHtml %}
+        {% if project.github %}
+          <a class="govuk-link" href="{{ project.github }}">{{ project.github }}</a>
+        {% else %}
+          Not found
+        {% endif %}
+      {% endset %}
 
-      <p class="govuk-body">Theme: <a class="govuk-link" href="/#{{ project.theme | slugify }}">{{ project.theme }}</a></p>
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
-      {% if project.github %}
-        <p class="govuk-body"><a class="govuk-link" href="{{ project.github }}">Source code</a></p>
-      {% endif %}
+      <h2 class="govuk-heading-m">About this service</h2>
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Organisation"
+            },
+            value: {
+              html: organisationHtml
+            }
+          },
+          {
+            key: {
+              text: "Theme"
+            },
+            value: {
+              html: themeHtml
+            }
+          },
+          {
+            key: {
+              text: "Status"
+            },
+            value: {
+              html: statusHtml
+            }
+          },
+          {
+            key: {
+              text: "Source code"
+            },
+            value: {
+              html: sourceCodeHtml
+            }
+          }
+        ]
+      }) }}
+
 
     </div>
   </div>


### PR DESCRIPTION
This moves the layout away from being based in columns for service status (alpha, beta, live and unknown), as these are increasingly irrelevant or hard to ascertain. Instead the services are shown as a simple list.

The navigation has also moved out of the black header section and into a grey bar, for improved visibility.

The font has switched to Helvetica Neue instead of GDS Transport, as this is not an official GOV.UK service.