### PR TITLE
Move service assessment links into a new "timeline" key

### DIFF
--- a/app/assets/sass/_timeline.scss
+++ b/app/assets/sass/_timeline.scss
@@ -1,0 +1,39 @@
+.app-timeline {
+  position: relative;
+  padding-left: 25px;
+}
+
+.app-timeline:before {
+  content: ' ';
+  position: absolute;
+  width: 5px;
+  height: 100%;
+  top: 10px;
+  left: 0;
+  background-color: govuk-colour("blue");
+}
+
+.app-timeline__item {
+  position: relative;
+}
+
+.app-timeline__item:before {
+  content: ' ';
+  position: absolute;
+  width: 10px;
+  height: 5px;
+  top: 10px;
+  left: -20px;
+  background-color: govuk-colour("blue");
+}
+
+.app-timeline__heading {
+  @include govuk-font(19, $weight: bold);
+  margin-bottom: 0;
+}
+
+.app-timeline__date {
+  @include govuk-font(19);
+  margin-top: 0;
+  margin-bottom: govuk-spacing(3);
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -14,6 +14,7 @@ $app-light-grey: #f8f8f8;
 @import "logo";
 @import "navigation";
 @import "tag";
+@import "timeline";
 
 // We don't change the global width container width so that examples are the current width.
 .app-width-container {

--- a/app/services/accelerated-possession-eviction.json
+++ b/app/services/accelerated-possession-eviction.json
@@ -6,5 +6,19 @@
   "phase": "live",
   "liveservice": "https://civilclaims.service.gov.uk/accelerated-possession-eviction",
   "github": "https://github.com/ministryofjustice/accelerated_claims",
-  "live-assessment": "https://dataingovernment.blog.gov.uk/civil-claims-accelerated-possession-service-assessment/"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed live assessment",
+        "date": "2014-07-15",
+        "links": [
+          {
+            "href": "https://dataingovernment.blog.gov.uk/civil-claims-accelerated-possession-service-assessment/",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for live assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/apply-for-divorce.json
+++ b/app/services/apply-for-divorce.json
@@ -5,5 +5,19 @@
   "organisation": "Ministry of Justice",
   "phase": "beta",
   "github": "https://github.com/hmcts/div-petitioner-frontend",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/apply-for-divorce"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2016-10-25",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/apply-for-divorce",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/apply-for-probate.json
+++ b/app/services/apply-for-probate.json
@@ -7,5 +7,23 @@
   "start-page": "https://www.gov.uk/applying-for-probate/apply-for-probate",
   "liveservice": "https://www.apply-for-probate.service.gov.uk/death-certificate",
   "github": "https://github.com/hmcts/probate-frontend",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/apply-for-probate-alpha-assessment"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2017-02-21",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/apply-for-probate-alpha-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      },
+      {
+        "label": "Did not meet alpha assessment",
+        "date": "2016-12-09"
+      }
+    ]
+  }
 }

--- a/app/services/biometric-residence-permits.json
+++ b/app/services/biometric-residence-permits.json
@@ -4,8 +4,22 @@
   "theme": "Citizenship and living in the UK",
   "organisation": "Home Office",
   "phase": "live",
-  "live-assessment": "https://www.gov.uk/service-standard-reports/biometric-residence-permits-brps",
   "github": "https://github.com/UKHomeOffice/brp_enquiry_forms",
   "liveservice": "https://www.gov.uk/biometric-residence-permits",
-  "performance-platform": "https://www.gov.uk/performance/biometric-residence-permit-enquiry-forms"
+  "performance-platform": "https://www.gov.uk/performance/biometric-residence-permit-enquiry-forms",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed live assessment",
+        "date": "2016-06-21",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/biometric-residence-permits-brps",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for live assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/campaigns-platform.json
+++ b/app/services/campaigns-platform.json
@@ -1,9 +1,24 @@
 {
   "name": "Campaigns platform",
-  "description": "Not available.",
+  "description": "A campaign is a planned sequence of communications and interactions that uses a compelling narrative over time to deliver a defined and measurable outcome.",
   "theme": "Government Internal",
   "organisation": "Government Digital Service",
   "phase": "alpha",
   "facing": "internal",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/campaigns-platform"
+  "liveservice": "https://gcs.civilservice.gov.uk/guidance/marketing/how-to-set-up-a-new-government-campaign-online/",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2016-09-21",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/campaigns-platform",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/carers-allowance.json
+++ b/app/services/carers-allowance.json
@@ -4,10 +4,24 @@
   "theme": "Benefits",
   "organisation": "Department for Work and Pensions",
   "phase": "live",
-  "live-assessment": "https://gdsdata.blog.gov.uk/carers-allowance-service-assessment",
   "prototype": "https://dwp-story.3cbeta.co.uk/URSept/",
   "video": "IYBLX3V8ek4",
   "start-page": "https://www.gov.uk/carers-allowance",
   "liveservice": "https://www.carersallowance.service.gov.uk/",
-  "github": "https://github.com/dwp/carers-allowance-prototype"
+  "github": "https://github.com/dwp/carers-allowance-prototype",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed live assessment",
+        "date": "2014-11-13",
+        "links": [
+          {
+            "href": "https://gdsdata.blog.gov.uk/carers-allowance-service-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for live assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/charity-search.json
+++ b/app/services/charity-search.json
@@ -2,6 +2,5 @@
   "name": "Registered charities in England and Wales",
   "description": "The public register of charities is being redesigned in line with user feedback to make information on charities easier to find and understand.",
   "organisation": "Charity Commission",
-  "phase": "beta",
-  "beta-assessment": "https://www.gov.uk/service-standard-reports/update-charity-details"
+  "phase": "beta"
 }

--- a/app/services/digital-first-careers.json
+++ b/app/services/digital-first-careers.json
@@ -1,8 +1,0 @@
-{
-  "name": "Digital First Careers",
-  "description": "The service provides a simple and clear way for citizens to understand career options available to them.",
-  "theme": "Working, jobs and pensions",
-  "organisation": "Department for Education",
-  "phase": "alpha",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/digital-first-careers-alpha-assessment"
-}

--- a/app/services/driving-medical-condition.json
+++ b/app/services/driving-medical-condition.json
@@ -6,6 +6,20 @@
   "phase": "beta",
   "liveservice": "https://www.driving-medical-condition.service.gov.uk/report",
   "start-page": "https://www.gov.uk/report-driving-medical-condition",
-  "beta-assessment": "https://www.gov.uk/service-standard-reports/fitness-to-drive",
-  "github": "https://github.com/dvla/Fitness-to-Drive-Pageflow"
+  "github": "https://github.com/dvla/Fitness-to-Drive-Pageflow",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed beta assessment",
+        "date": "2016-08-24",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/fitness-to-drive",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for beta assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/file-company-accounts.json
+++ b/app/services/file-company-accounts.json
@@ -4,5 +4,19 @@
   "theme": "Business and self-employed",
   "organisation": "Companies House",
   "phase": "alpha",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/file-company-accounts-alpha-assessment"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2017-02-15",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/file-company-accounts-alpha-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/help-with-fees.json
+++ b/app/services/help-with-fees.json
@@ -1,12 +1,25 @@
 {
-  "name": "Help With Fees",
+  "name": "Get help paying court and tribunal fees",
   "description": "You might be able to get money off your court or tribunal fees if you have little or no savings, are on certain benefits or have a low income. There are different ways of applying for help with fees for the Court of Protection and the First-Tier Immigration and Asylum Tribunal.",
   "theme": "Crime, justice and the law",
   "organisation": "Ministry of Justice",
   "phase": "beta",
-  "phase_modifier": "Public",
-  "beta-assessment": "https://www.gov.uk/service-standard-reports/help-with-fees",
   "start-page": "https://www.gov.uk/get-help-with-court-fees",
   "liveservice": "https://helpwithcourtfees.service.gov.uk/",
-  "github": "https://github.com/ministryofjustice/hwf-publicapp"
+  "github": "https://github.com/ministryofjustice/hwf-publicapp",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2016-06-14",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/help-with-fees",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/licencing-international-trade.json
+++ b/app/services/licencing-international-trade.json
@@ -4,5 +4,23 @@
   "theme": "Business and self-employed",
   "organisation": "Department for Business, Energy & Industrial Strategy",
   "phase": "alpha",
-  "beta-assessment": "https://www.gov.uk/service-standard-reports/licensing-for-international-trade-alpha-assessment"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2017-06-28",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/licensing-for-international-trade-alpha-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      },
+      {
+        "label": "Did not pass alpha assessment",
+        "date": "2017-05-27"
+      }
+    ]
+  }
 }

--- a/app/services/local-land-charges.json
+++ b/app/services/local-land-charges.json
@@ -4,6 +4,31 @@
   "theme": "Housing and local services",
   "organisation": "Land Registry",
   "phase": "beta",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/local-land-charges-alpha-assessment",
-  "liveservice": "https://search-local-land-charges.service.gov.uk"
+  "liveservice": "https://search-local-land-charges.service.gov.uk",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed beta assessment",
+        "date": "2018-11-01",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/search-for-local-land-charges-and-maintain-local-land-charges-beta-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for beta assessment"
+          }
+        ]
+      },
+      {
+        "label": "Did not meet alpha assessment",
+        "date": "2017-01-31",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/local-land-charges-alpha-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/nationalcareers.json
+++ b/app/services/nationalcareers.json
@@ -4,5 +4,20 @@
   "organisation": "Education and Skills Funding Agency",
   "theme": "Education, training and skills",
   "phase": "beta",
-  "liveservice": "https://nationalcareers.service.gov.uk"
+  "liveservice": "https://nationalcareers.service.gov.uk",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2017-01-30",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/digital-first-careers-alpha-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/nhs-111.json
+++ b/app/services/nhs-111.json
@@ -6,5 +6,19 @@
   "organisation": "NHS Digital",
   "github": "https://github.com/111Online",
   "liveservice": "https://111.nhs.uk",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/nhs-111"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2016-04-28",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/nhs-111",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/register-with-a-gp.json
+++ b/app/services/register-with-a-gp.json
@@ -4,5 +4,19 @@
   "theme": "Births, deaths, marriages and care",
   "organisation": "NHS Digital",
   "phase": "alpha",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/register-with-a-gp-practice-alpha-assessment"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2017-01-09",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/register-with-a-gp-practice-alpha-assessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/social-security-child-support.json
+++ b/app/services/social-security-child-support.json
@@ -4,5 +4,19 @@
   "theme": "Crime, justice and the law",
   "organisation": "Ministry of Justice",
   "phase": "alpha",
-  "alpha-assessment": "https://www.gov.uk/service-standard-reports/social-security-and-child-support-tribunal"
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed alpha assessment",
+        "date": "2016-11-29",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/social-security-and-child-support-tribunal",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for alpha assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/update-charity-details.json
+++ b/app/services/update-charity-details.json
@@ -4,7 +4,21 @@
   "theme": "Money and tax",
   "organisation": "The Charity Commission",
   "phase": "beta",
-  "beta-assessment": "https://www.gov.uk/service-standard-reports/update-charity-details",
   "liveservice": "https://portal.update-charity-details.service.gov.uk/group/update-charity-details",
-  "start-page": "https://www.gov.uk/change-your-charitys-details"
+  "start-page": "https://www.gov.uk/change-your-charitys-details",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed beta assessment",
+        "date": "2016-07-29",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/update-charity-details",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for beta assessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/services/wifi.json
+++ b/app/services/wifi.json
@@ -3,6 +3,32 @@
   "description": "GovWifi is a wifi authentication service allowing staff and visitors to use a single username and password to connect to guest wifi across the public sector.",
   "organisation": "Government Digital Service",
   "theme": "Government Internal",
-  "phase": "beta",
-  "liveservice": "https://www.wifi.service.gov.uk"
+  "phase": "live",
+  "liveservice": "https://www.wifi.service.gov.uk",
+  "timeline": {
+    "items": [
+      {
+        "label": "Passed live assessment",
+        "date": "2021-09-16",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/govwifi",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for live assessment"
+          }
+        ]
+      },
+      {
+        "label": "Passed beta reassessment",
+        "date": "2017-04-27",
+        "links": [
+          {
+            "href": "https://www.gov.uk/service-standard-reports/gov-wifi-beta-reassessment",
+            "text": "Service assessment report",
+            "visuallyHiddenText": " for beta reassessment"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/app/views/project.html
+++ b/app/views/project.html
@@ -98,6 +98,27 @@
         ]
       }) }}
 
+      {% if project.timeline and project.timeline.items|length > 0 %}
+        <h2 class="govuk-heading-m">Service history</h2>
+
+        <div class="app-timeline">
+          {% for item in project.timeline.items %}
+            <div class="app-timeline__item">
+              <h3 class="app-timeline__heading">{{ item.label }}</h3>
+              <p class="app-timeline__date"><time datetime="{{ item.date }}">{{ item.date | formatdate }}</time></p>
+
+              {% if item.links and item.links|length > 0 %}
+                <ul class="govuk-list">
+                  {% for link in item.links %}
+                    <li><a class="govuk-link" href="{{ link.href }}">{{ link.text }}{% if link.visuallyHiddenText %}<span class="govuk-visually-hidden">{{ link.visuallyHiddenText }}</span>{% endif %}</a></li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
 
     </div>
   </div>

--- a/start.js
+++ b/start.js
@@ -143,6 +143,27 @@ env.addFilter('slugify', function(str) {
   return str.replace(/[.,-\/#!$%\^&\*;:{}=\-_`~()’]/g,"").replace(/ +/g,'_').toLowerCase();
 });
 
+env.addFilter('formatdate', function(str) {
+  var date = new Date(str);
+
+  var monthNames = {
+    0: "January",
+    1: "February",
+    2: "March",
+    3: "April",
+    4: "May",
+    5: "June",
+    6: "July",
+    7: "August",
+    8: "September",
+    9: "October",
+    10: "November",
+    11: "December"
+  }
+
+  return `${date.getDate()} ${monthNames[date.getMonth()]} ${date.getFullYear()}`
+});
+
 app.get('/projects/:slug', function (req, res) {
   project = req.app.locals.projects.filter(function(p) { return p.slug == req.params.slug})[0]
   res.render('project.html', {


### PR DESCRIPTION
This is more flexible, allowing other events such as launches or key milestones.