### PR TITLE
Remove GitHub link for register-to-vote

### DIFF
--- a/app/services/register-to-vote.json
+++ b/app/services/register-to-vote.json
@@ -5,6 +5,5 @@
   "theme": "Citizenship and living in the UK",
   "phase": "live",
   "start-page": "https://www.gov.uk/register-to-vote",
-  "liveservice": "https://www.registertovote.service.gov.uk/",
-  "github": "https://github.com/alphagov/ier-frontend"
+  "liveservice": "https://www.registertovote.service.gov.uk/"
 }


### PR DESCRIPTION
As the linked repo is no longer in use.