### PR TITLE
Update energy certificate services

### DIFF
--- a/app/services/find-energy-certificate.json
+++ b/app/services/find-energy-certificate.json
@@ -4,8 +4,8 @@
   "organisation": "Department for Levelling Up, Housing & Communities",
   "theme": "Housing and local services",
   "phase": "beta",
-  "liveservice": "https://find-energy-certificate.digital.communities.gov.uk",
-  "start-page": "https://www.gov.uk/buy-sell-your-home/energy-performance-certificates",
+  "liveservice": "https://find-energy-certificate.service.gov.uk/find-a-certificate/type-of-property",
+  "start-page": "https://www.gov.uk/find-energy-certificate",
   "timeline": {
     "items": [
       {

--- a/app/services/getting-energy-certificate.json
+++ b/app/services/getting-energy-certificate.json
@@ -1,9 +1,9 @@
 {
-  "name": "Getting a new energy certificate",
+  "name": "Get a new energy certificate",
   "description": "To get an energy performance certificate for your home, you to need have your property assessed. Search for an accredited assessor in your area.",
   "organisation": "Department for Levelling Up, Housing & Communities",
   "theme": "Housing and local services",
   "phase": "beta",
-  "liveservice": "https://getting-new-energy-certificate.digital.communities.gov.uk/find-an-assessor/search-by-postcode",
-  "start-page": "https://www.gov.uk/find-an-energy-assessor"
+  "liveservice": "https://getting-new-energy-certificate.service.gov.uk/find-an-assessor/type-of-property",
+  "start-page": "https://www.gov.uk/get-new-energy-certificate"
 }


### PR DESCRIPTION
Moved onto `*.service.gov.uk` domains, and new start pages on GOV.UK.