### PR TITLE
Remove www from Teaching Vacancies service

### DIFF
--- a/app/services/teaching-vacancies.json
+++ b/app/services/teaching-vacancies.json
@@ -4,7 +4,7 @@
   "theme": "Working, jobs and pensions",
   "organisation": "Department for Education",
   "phase": "beta",
-  "liveservice": "https://www.teaching-vacancies.service.gov.uk/",
+  "liveservice": "https://teaching-vacancies.service.gov.uk/",
   "start-page": "https://www.gov.uk/find-teaching-job",
   "github": "https://github.com/DFE-Digital/teaching-vacancies"
 }


### PR DESCRIPTION
This seems to have been dropped from the URL.