### PR TITLE
Update URLs of DfE services

### DIFF
--- a/app/services/get-help-buying-for-schools.json
+++ b/app/services/get-help-buying-for-schools.json
@@ -4,6 +4,6 @@
   "organisation": "Department for Education",
   "theme": "Education, training and skills",
   "phase": "beta",
-  "liveservice": "https://get-help-buying-for-schools.education.gov.uk",
+  "liveservice": "https://www.get-help-buying-for-schools.service.gov.uk",
   "github": "https://github.com/DFE-Digital/buy-for-your-school"
 }

--- a/app/services/publish-teacher-training-courses.json
+++ b/app/services/publish-teacher-training-courses.json
@@ -4,6 +4,6 @@
   "theme": "Education, training and skills",
   "organisation": "Department for Education",
   "phase": "beta",
-  "liveservice": "https://www.publish-teacher-training-courses.education.gov.uk",
+  "liveservice": "https://www.publish-teacher-training-courses.service.gov.uk",
   "github": "https://github.com/DFE-Digital/publish-teacher-training"
 }


### PR DESCRIPTION
These 2 are now on a *.service.gov.uk domain.