### PR TITLE
Update styles to align with other X-GOVUK websites

### DIFF
--- a/app/assets/sass/_header.scss
+++ b/app/assets/sass/_header.scss
@@ -27,8 +27,3 @@
     }
   }
 }
-
-
-.app-header__container {
-  border-bottom-color: #28a;
-}

--- a/app/assets/sass/_header.scss
+++ b/app/assets/sass/_header.scss
@@ -2,6 +2,11 @@
 // See: https://github.com/alphagov/govuk-design-system/blob/master/src/stylesheets/components/_header.scss
 
 @include govuk-exports("app-header") {
+  // Show border along full length of header to match navigation below
+  .app-header {
+    border-color: $govuk-brand-colour;
+  }
+
   // Override the default 33% width on the logo in GOV.UK Frontend (prevents
   // unnecessary wrapping of product name on smaller tablet / desktop
   // viewports)

--- a/app/assets/sass/_navigation.scss
+++ b/app/assets/sass/_navigation.scss
@@ -1,52 +1,65 @@
-$navigation-height: 50px;
-
 .app-navigation {
   @include govuk-font(19, $weight: bold);
-  box-sizing: border-box;
-  width: 100%;
-  background-color: $app-light-grey;
+  background-color: govuk-colour("light-grey");
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.govuk-phase-banner + .app-navigation {
+  margin-top: -1px;
 }
 
 .app-navigation__list {
-  position: relative;
-  left: -(govuk-spacing(3));
+  @include govuk-clearfix;
+  left: govuk-spacing(-3);
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
+  position: relative;
+  right: govuk-spacing(-3);
+  width: calc(100% + #{govuk-spacing(6)});
 }
 
-.app-navigation__list-item {
+.app-navigation__item {
   box-sizing: border-box;
   display: block;
-  position: relative;
-  height: $navigation-height;
-  padding: 0 govuk-spacing(3);
   float: left;
-  line-height: $navigation-height;
+  line-height: 50px;
+  height: 50px;
+  padding: 0 govuk-spacing(3);
+  position: relative;
 }
 
-.app-navigation__list-item--current {
-  border-bottom: 4px solid govuk-colour("blue");
+.app-navigation__item--current {
+  border-bottom: $govuk-border-width-narrow solid $govuk-link-colour;
+
+  &:hover {
+    border-bottom-color: $govuk-link-hover-colour;
+  }
+
+  &:active {
+    border-bottom-color: $govuk-link-active-colour;
+  }
+}
+
+.app-navigation__item--align-right {
+  @include govuk-media-query($from: tablet) {
+    float: right;
+  }
 }
 
 .app-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+  @include govuk-link-style-no-underline;
   @include govuk-typography-weight-bold;
-
-  &:not(:focus):hover {
-    color: $govuk-link-colour;
-  }
 
   // Extend the touch area of the link to the list
   &:after {
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
     bottom: 0;
+    content: "";
     left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
   }
-}
-
-.app-navigation__list-item--current .app-navigation__link:hover {
-  text-decoration: none;
 }

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,7 +1,7 @@
 $govuk-new-link-styles: true;
 
 // Override the default GOV.UK Frontend font stack
-$govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+$govuk-font-family: system-ui, sans-serif;
 
 @import "govuk-frontend/govuk/all";
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -2,6 +2,7 @@ $govuk-new-link-styles: true;
 
 // Override the default GOV.UK Frontend font stack
 $govuk-font-family: system-ui, sans-serif;
+$govuk-brand-colour: #28a;
 
 @import "govuk-frontend/govuk/all";
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -6,9 +6,6 @@ $govuk-brand-colour: #28a;
 
 @import "govuk-frontend/govuk/all";
 
-// App-specific variables
-$app-light-grey: #f8f8f8;
-
 @import "count";
 @import "header";
 @import "list";

--- a/app/views/includes/_header.html
+++ b/app/views/includes/_header.html
@@ -3,41 +3,29 @@
     <div class="govuk-header__logo app-header__logo">
       <a href="/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
-<svg class="app-header__logotype--large" aria-hidden="true" focusable="false" height="35" width="35" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
-  <path fill="currentColor" d="M180 251v1c-17 7-26 12-26 16s19 6 19-5c4 18-11 21-20 13 4 7 6 18-4 23-11-5-9-16-5-23-10 8-24 4-20-12v-1c0 11 18 9 19 5 0-4-9-9-26-16v-1c11 3 21 4 32 4 10 0 20-1 31-4Zm61-52 1 1c-6 18-8 29-5 34 6-6 11-14 11-24l19 9c-11 5-20 10-27 17 5 2 15-1 21-4l-32 32c3-6 6-16 4-21-7 6-12 16-16 27l-10-19c11 0 18-5 24-11-5-3-16-2-34 5v-1c10-6 18-12 25-19 8-8 14-15 19-26Zm-186 0c6 10 12 18 20 25 7 8 15 14 25 20h-1c-17-6-29-7-33-4 6 5 13 11 24 11l-10 19c-4-12-10-21-16-28-2 5 1 16 3 21l-31-31c5 2 16 5 21 3-7-6-16-12-28-16l19-10c0 11 6 18 11 24 3-5 2-16-4-33Zm152-5a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm-115 0a15 15 0 0 1 11 25 15 15 0 0 1-25-10 15 15 0 0 1 14-15Zm88-27a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm-63 0a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm133-48c7 17 12 26 16 26s6-19-5-19c18-4 21 11 13 20 7-4 18-6 23 5-5 10-16 8-23 4 8 9 5 24-13 20 11 0 9-19 5-19s-9 9-16 26h-1c3-11 4-21 4-31 0-11-1-21-4-32h1Zm-202 0c-3 11-4 21-4 32 0 10 1 20 4 31h-1c-7-17-12-26-15-26-5 0-7 19 4 19-18 4-21-11-13-20-7 4-18 6-23-4 5-11 16-9 23-5-8-9-5-24 13-20-11 0-9 19-4 19 3 0 8-9 15-26Zm101 11a20 20 0 1 1-1 41 20 20 0 0 1 1-41Zm-32-26a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm63 0a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15ZM92 80a15 15 0 0 1 11 25 15 15 0 0 1-25-11 15 15 0 0 1 14-14Zm115 0a15 15 0 0 1 10 25 15 15 0 0 1-25-11 15 15 0 0 1 15-14ZM80 32l9 19c-10 0-18 5-24 11 5 3 16 1 34-5l1 1c-11 5-18 11-26 19-7 7-13 15-19 25h-1c7-18 8-29 5-34-6 6-11 13-11 24L29 82c11-4 21-9 27-16-5-2-15 1-21 4l32-32c-3 6-6 16-4 21 7-7 12-16 17-27Zm137-1c4 12 10 21 16 28 2-5-1-16-3-21l31 31c-5-2-16-5-21-3 7 6 16 12 28 16l-19 10c0-11-6-18-11-24-3 4-2 16 4 33v1c-6-10-12-18-20-25-7-8-15-14-25-20h1c17 6 28 7 33 4-6-5-13-11-24-11l10-19ZM149 2c10 5 8 16 4 23 9-8 24-5 20 13 0-11-19-9-19-4 0 3 9 8 26 15v1c-11-3-21-4-31-4-11 0-21 1-32 4v-1c17-7 26-12 26-15 0-5-19-7-19 4-4-17 10-21 20-13-4-7-6-18 5-23Z"/>
-</svg>
-          <span class="govuk-header__logotype-text">
-            X-GOVUK
-          </span>
+          <svg class="app-header__logotype--large" aria-hidden="true" focusable="false" height="35" width="35" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+            <path fill="currentColor" d="M180 251v1c-17 7-26 12-26 16s19 6 19-5c4 18-11 21-20 13 4 7 6 18-4 23-11-5-9-16-5-23-10 8-24 4-20-12v-1c0 11 18 9 19 5 0-4-9-9-26-16v-1c11 3 21 4 32 4 10 0 20-1 31-4Zm61-52 1 1c-6 18-8 29-5 34 6-6 11-14 11-24l19 9c-11 5-20 10-27 17 5 2 15-1 21-4l-32 32c3-6 6-16 4-21-7 6-12 16-16 27l-10-19c11 0 18-5 24-11-5-3-16-2-34 5v-1c10-6 18-12 25-19 8-8 14-15 19-26Zm-186 0c6 10 12 18 20 25 7 8 15 14 25 20h-1c-17-6-29-7-33-4 6 5 13 11 24 11l-10 19c-4-12-10-21-16-28-2 5 1 16 3 21l-31-31c5 2 16 5 21 3-7-6-16-12-28-16l19-10c0 11 6 18 11 24 3-5 2-16-4-33Zm152-5a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm-115 0a15 15 0 0 1 11 25 15 15 0 0 1-25-10 15 15 0 0 1 14-15Zm88-27a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm-63 0a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm133-48c7 17 12 26 16 26s6-19-5-19c18-4 21 11 13 20 7-4 18-6 23 5-5 10-16 8-23 4 8 9 5 24-13 20 11 0 9-19 5-19s-9 9-16 26h-1c3-11 4-21 4-31 0-11-1-21-4-32h1Zm-202 0c-3 11-4 21-4 32 0 10 1 20 4 31h-1c-7-17-12-26-15-26-5 0-7 19 4 19-18 4-21-11-13-20-7 4-18 6-23-4 5-11 16-9 23-5-8-9-5-24 13-20-11 0-9 19-4 19 3 0 8-9 15-26Zm101 11a20 20 0 1 1-1 41 20 20 0 0 1 1-41Zm-32-26a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15Zm63 0a15 15 0 0 1 10 25 15 15 0 0 1-25-10 15 15 0 0 1 15-15ZM92 80a15 15 0 0 1 11 25 15 15 0 0 1-25-11 15 15 0 0 1 14-14Zm115 0a15 15 0 0 1 10 25 15 15 0 0 1-25-11 15 15 0 0 1 15-14ZM80 32l9 19c-10 0-18 5-24 11 5 3 16 1 34-5l1 1c-11 5-18 11-26 19-7 7-13 15-19 25h-1c7-18 8-29 5-34-6 6-11 13-11 24L29 82c11-4 21-9 27-16-5-2-15 1-21 4l32-32c-3 6-6 16-4 21 7-7 12-16 17-27Zm137-1c4 12 10 21 16 28 2-5-1-16-3-21l31 31c-5-2-16-5-21-3 7 6 16 12 28 16l-19 10c0-11-6-18-11-24-3 4-2 16 4 33v1c-6-10-12-18-20-25-7-8-15-14-25-20h1c17 6 28 7 33 4-6-5-13-11-24-11l10-19ZM149 2c10 5 8 16 4 23 9-8 24-5 20 13 0-11-19-9-19-4 0 3 9 8 26 15v1c-11-3-21-4-31-4-11 0-21 1-32 4v-1c17-7 26-12 26-15 0-5-19-7-19 4-4-17 10-21 20-13-4-7-6-18 5-23Z"/>
+          </svg>
+          <span class="govuk-header__logotype-text">X-GOVUK</span>
         </span>
-        <span class="govuk-header__product-name">
-          Services list
-        </span>
+        <span class="govuk-header__product-name">Services list</span>
       </a>
     </div>
   </div>
 </header>
 
-<nav class="app-navigation govuk-clearfix">
+<nav class="app-navigation">
   <div class="govuk-width-container">
     <ul class="app-navigation__list">
-
-      <li class="app-navigation__list-item">
-        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link" href="/">
-          By theme
-        </a>
+      <li class="app-navigation__item">
+        <a class="app-navigation__link" href="/">By theme</a>
       </li>
-      <li class="app-navigation__list-item">
-        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link" href="/organisation">
-          By organisation
-        </a>
+      <li class="app-navigation__item">
+        <a class="app-navigation__link" href="/organisation">By organisation</a>
       </li>
-      <li class="app-navigation__list-item">
-        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link" href="/contribute">
-          Contribute
-        </a>
+      <li class="app-navigation__item">
+        <a class="app-navigation__link" href="/contribute">Contribute</a>
       </li>
-
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
I noticed you updated the header to match the other sites – nice! This PR tweaks a few things to ensure things align a little better.

Before:

<img width="1140" alt="Screenshot 2022-06-24 at 19 19 33" src="https://user-images.githubusercontent.com/813383/175630691-608c1f7f-35f6-4912-86a8-42253f298a13.png">

After:

<img width="1140" alt="Screenshot 2022-06-24 at 19 19 49" src="https://user-images.githubusercontent.com/813383/175631118-48db8d8e-93a6-4b21-b9ca-a6795e67ee6c.png">
