### PR TITLE
Update service name: Attendance allowance

### DIFF
--- a/app/services/attendance-allowance.json
+++ b/app/services/attendance-allowance.json
@@ -1,5 +1,8 @@
 {
-  "name": "Attendance allowance",
+  "name": "Claim attendance allowance",
+  "synonyms": [
+    "Attendance allowance"
+  ],
   "description": "Attendance Allowance (AA) is a benefit to help with extra costs if the claimant has a disability severe enough that they need help or supervision from someone else.",
   "organisation": "Department for Work and Pensions",
   "theme": "Benefits",


### PR DESCRIPTION
According to [this list](https://www.gov.uk/government/publications/roadmap-for-digital-and-data-2022-to-2025/transforming-for-a-digital-future-2022-to-2025-roadmap-for-digital-and-data#annex) the service is now called 'Claim attendance allowance'.