### PR TITLE
Update service name: Carer’s Allowance

### DIFF
--- a/app/services/carers-allowance.json
+++ b/app/services/carers-allowance.json
@@ -1,5 +1,9 @@
 {
-  "name": "Carer’s Allowance",
+  "name": "Apply for Carer’s Allowance",
+  "synonyms": [
+    "Carer’s Allowance",
+    "Claim Carer’s Allowance"
+  ],
   "description": "Lets users who care for another person for more than 35 hours a week get a regular payment so that they can carry on giving care.",
   "theme": "Benefits",
   "organisation": "Department for Work and Pensions",


### PR DESCRIPTION
The live service uses the name "Apply for Carer’s Allowance" in its header.