### PR TITLE
Add service: Claim Disability Living Allowance For A Child

### DIFF
--- a/app/services/disability-living-allowance-children.json
+++ b/app/services/disability-living-allowance-children.json
@@ -1,0 +1,14 @@
+{
+  "name": "Claim Disability Living Allowance For A Child",
+  "synonyms": [
+    "Disability Living Allowance (DLA) for children"
+  ],
+  "description": "Disability Living Allowance (DLA) for children may help with the extra costs of looking after a child who is under 16 and has difficulties walking or needs much more looking after than a child of the same age who does not have a disability",
+  "theme": "Benefits",
+  "organisation": "Department for Work and Pensions",
+  "phase": "alpha",
+  "start-page": "https://www.gov.uk/disability-living-allowance-children",
+  "tags": [
+    "Top 75"
+  ]
+}


### PR DESCRIPTION
Not yet live (downloadable form only), but a 'top 75' service for DWP.