### PR TITLE
Update organisational info on get a rod fishing licence

### DIFF
--- a/app/services/buy-fishing-licence.json
+++ b/app/services/buy-fishing-licence.json
@@ -8,7 +8,7 @@
   ],
   "description": "You can buy a 1-day, 8-day or 12-month licence online.",
   "theme": "Environment and countryside",
-  "organisation": "Department for Environment, Food & Rural Affairs",
+  "organisation": "Environment Agency",
   "phase": "live",
   "liveservice": "https://get-fishing-licence.service.gov.uk/",
   "start-page": "https://www.gov.uk/fishing-licences/buy-a-fishing-licence",


### PR DESCRIPTION
As per the response to [these](https://www.whatdotheyknow.com/request/buy_a_rod_fishing_licence_and_ad) [two](https://www.whatdotheyknow.com/request/buy_a_rod_fishing_licence_and_ad_2) FOI requests the "get a rod fishing licence" appears to be managed by the Environment Agency, rather than DEFRA itself