### PR TITLE
Fix layout of image

### DIFF
--- a/app/assets/sass/_screenshot.scss
+++ b/app/assets/sass/_screenshot.scss
@@ -1,4 +1,5 @@
 .app-screenshot {
+  box-sizing: border-box;
   max-width: 100%;
   padding: 10px;
   border: 1px solid $govuk-border-colour;


### PR DESCRIPTION
This needs to use `box-sizing: border-box` in order to fit in properly on a smaller screen.