### PR TITLE
Add instructions for taking screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ npm start
 
 ## How to add or update screenshots
 
-Screenshots of services (the first page) can be added automatically by running a script.
+Screenshots for service landing or home pages can be added automatically by running a script.
 
 First, you need to have the latest version of [Google Chrome](https://www.google.com/chrome/) installed.
 
-You then need to tell the script exactly where this is installed on your computer. Add the full path to the
-Google Chrome executable by adding it to a file named `.env` (in the same folder as this README file), using this
+To tell the script where the Google Chrome executable is installed on your computer, add the full path to a file named `.env` (in the same folder as this README file), using this
 named environment variable:
 
 `GOOGLE_CHROME_PATH=""`

--- a/README.md
+++ b/README.md
@@ -28,3 +28,35 @@ Using a command line run
 npm install
 npm start
 ```
+
+## How to add or update screenshots
+
+Screenshots of services (the first page) can be added automatically by running a script.
+
+First, you need to have the latest version of [Google Chrome](https://www.google.com/chrome/) installed.
+
+You then need to tell the script exactly where this is installed on your computer. Add the full path to the
+Google Chrome executable by adding it to a file named `.env` (in the same folder as this README file), using this
+named environment variable:
+
+`GOOGLE_CHROME_PATH=""`
+
+For example, on a Mac, this may be something like this:
+
+`GOOGLE_CHROME_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"`
+
+Once this is set up, you can run the script to add the screenshots using this command:
+
+`npm run screenshots register-to-vote`
+
+Substitute `register-to-vote` with the name of the file for the service you want to screenshot.
+
+You can also update all the screenshots (which will take a while) by running this:
+
+`npm run screenshots all`
+
+Screenshots will be saved in the `app/assets/images/service-screenshots` folder, using the same name as the json file
+within `app/services`. Images are all 2160x2160 pixels (1080x1080 at 2x resolution), and will be rendered with no cookies
+set (and so will include any cookie banner).
+
+

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Screenshots for service landing or home pages can be added automatically by runn
 
 First, you need to have the latest version of [Google Chrome](https://www.google.com/chrome/) installed.
 
-To tell the script where the Google Chrome executable is installed on your computer, add the full path to a file named `.env` (in the same folder as this README file), using this
-named environment variable:
+To tell the script where the Google Chrome executable is located on your computer, create a file named `.env` (in the same folder as this `README.md` file) and add this named environment variable:
 
 `GOOGLE_CHROME_PATH=""`
 
@@ -50,12 +49,10 @@ Once this is set up, you can run the script to add the screenshots using this co
 
 Substitute `register-to-vote` with the name of the file for the service you want to screenshot.
 
-You can also update all the screenshots (which will take a while) by running this:
+You can also update all the screenshots (which will take a while) by running this command:
 
 `npm run screenshots all`
 
-Screenshots will be saved in the `app/assets/images/service-screenshots` folder, using the same name as the json file
-within `app/services`. Images are all 2160x2160 pixels (1080x1080 at 2x resolution), and will be rendered with no cookies
-set (and so will include any cookie banner).
+Screenshots will be saved in the `app/assets/images/service-screenshots` folder, using the same name as the json file within `app/services`. Images are all 2160×2160 pixels (1080x1080 at 2× resolution), and will be rendered with no cookies set (so will include any cookie banner).
 
 


### PR DESCRIPTION
Resolves #607.

Possibly there's a way to make this easier, perhaps by assuming some default locations for Google Chrome on Mac or PC, but that'll need separate investigation.

Could also investigate switching to the `puppeteer` npm module, which installs its own version of Chrome, but I think I tried that previously and switched away from it for some reason (maybe to do with trying to get it working on Heroku?).

My longer-term aim was to have this script run automatically once a week and generate its own pull requests with any changes.