### PR TITLE
Remove CLA from Top 75

### DIFF
--- a/data/services/check-legal-aid.json
+++ b/data/services/check-legal-aid.json
@@ -1,12 +1,11 @@
 {
   "name": "Check if you can get legal aid",
-  "description": "Legal aid can help pay for legal advice.You’ll be asked general questions about your legal problem and your income and savings. You’ll be told where you can get legal advice.",
+  "description": "Legal aid can help pay for legal advice. You’ll be asked general questions about your legal problem and your income and savings. You’ll be told where you can get legal advice.",
   "theme": "Crime, justice and the law",
   "organisation": "Ministry of Justice",
   "phase": "Live",
   "liveService": "https://checklegalaid.service.gov.uk/start?locale=en_GB",
   "startPage": "https://www.gov.uk/check-legal-aid",
-  "tags": ["Top 75"],
   "sourceCode": [
     {
       "text": "Source code",


### PR DESCRIPTION
This service (CLA) was never on the Top 75 - I believe it was added to that in error, maybe because it was mistaken for *Apply* for Legal Advice. Was added here: https://github.com/x-govuk/govuk-services-list/pull/326/files#diff-b4bb9a2ccc6e3c67cca736de0ac2075e26d5beba2f9603cb36c3c40b34c9d1a7