### PR TITLE
Retire manage training for early career teachers

### DIFF
--- a/data/services/manage-training-for-early-career-teachers.json
+++ b/data/services/manage-training-for-early-career-teachers.json
@@ -3,7 +3,7 @@
   "description": "This service is for induction tutors who have been nominated by their school Use this service to manage your school’s statutory induction programme for early career teachers.",
   "organisation": "Department for Education",
   "theme": "Education and learning",
-  "phase": "Beta",
+  "phase": "Retired",
   "liveService": "https://manage-training-for-early-career-teachers.education.gov.uk",
   "sourceCode": [
     {


### PR DESCRIPTION
This service was retired in April and replaced by register early career teachers